### PR TITLE
kmake.mk: Use tar compression option '-j' for bzip2 compression

### DIFF
--- a/kmake.mk
+++ b/kmake.mk
@@ -656,7 +656,7 @@ $(addprefix dist-,$(DIST_SUFFIXES)): dist-%: $(DIST_FOLDER).tar.%
 
 $(DIST_FOLDER).tar.xz: COMP=J
 $(DIST_FOLDER).tar.gz: COMP=z
-$(DIST_FOLDER).tar.bz2: COMP=z
+$(DIST_FOLDER).tar.bz2: COMP=j
 $(addprefix $(DIST_FOLDER).tar.,$(DIST_SUFFIXES)): dist
 	$(call printcmd,TAR,$@)
 	$(Q)rm -f $@


### PR DESCRIPTION
Fix tar compression option for bzip2 compression ('j' instead of 'z').

Fixes: 33d1ff3 ("basic support for package distributing (tarball)")
Signed-off-by: Nicolas Schier <n.schier@avm.de>